### PR TITLE
Potential fix for code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/main.js
+++ b/main.js
@@ -217,18 +217,18 @@ function updateUI(room) {
         // 回答中は問題文を全文表示し、問題表示のアニメーションを止める
         if (room.buzzer?.pressedBy || room.gameStatusText) {
             buzzerButton.disabled = true;
-            questionBox.innerHTML = fullQuestion;
+            questionBox.textContent = fullQuestion;
             if (room.buzzer?.pressedBy === currentPlayerId) {
                 answerForm.classList.remove('hidden');
                 answerInput.focus();
             }
         } else {
             // 問題文を1文字ずつ表示
-            questionBox.innerHTML = '';
+            questionBox.textContent = '';
             let charIndex = 0;
             questionIntervalId = setInterval(() => {
                 if (charIndex < fullQuestion.length) {
-                    questionBox.innerHTML += fullQuestion[charIndex];
+                    questionBox.textContent += fullQuestion[charIndex];
                     charIndex++;
                 } else {
                     clearInterval(questionIntervalId);


### PR DESCRIPTION
Potential fix for [https://github.com/shisuke-glitch/quiz-app/security/code-scanning/2](https://github.com/shisuke-glitch/quiz-app/security/code-scanning/2)

To fix this vulnerability, we must ensure that any user-controlled data rendered into the DOM is properly escaped or sanitized before being assigned to `innerHTML`. The best way to do this is to avoid using `innerHTML` for plain text, and instead use `textContent`, which automatically escapes any HTML. If you need to preserve some formatting (e.g., line breaks), you can escape the text and then replace newlines with `<br>` safely, or use a well-known library like `dompurify` to sanitize HTML if rich text is required.

In this case, since `fullQuestion` is likely just a question string, we should use `textContent` instead of `innerHTML` when displaying it. This change should be made on line 220 and in the interval at line 231. If you need to preserve the animation (adding one character at a time), you should also use `textContent` in the interval.

**Required changes:**
- Replace `questionBox.innerHTML = fullQuestion;` with `questionBox.textContent = fullQuestion;`
- Replace `questionBox.innerHTML += fullQuestion[charIndex];` with a method that appends to `textContent` (e.g., `questionBox.textContent += fullQuestion[charIndex];`)
- No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
